### PR TITLE
URL Cleanup

### DIFF
--- a/client/src/main/resources/application.yml
+++ b/client/src/main/resources/application.yml
@@ -9,7 +9,7 @@ eureka:
   password: password
   client:
     serviceUrl:
-      defaultZone: http://user:${eureka.password}@localhost:8761/eureka/
+      defaultZone: https://user:${eureka.password}@localhost:8761/eureka/
   instance:
     leaseRenewalIntervalInSeconds: 10
     metadataMap:

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -9,7 +9,7 @@ eureka:
   password: password
   client:
     serviceUrl:
-      defaultZone: http://user:${eureka.password}@localhost:8761/eureka/
+      defaultZone: https://user:${eureka.password}@localhost:8761/eureka/
   instance:
     leaseRenewalIntervalInSeconds: 10
     metadataMap:


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://user (UnknownHostException) with 2 occurrences migrated to:  
  https://user ([https](https://user) result UnknownHostException).

# Ignored
These URLs were intentionally ignored.

* http://localhost:7111 with 2 occurrences
* http://localhost:7211 with 4 occurrences
* http://localhost:8761 with 1 occurrences